### PR TITLE
🐛  FIX (routes): resolve unmatched route param names

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -23,7 +23,7 @@ const AppRoutes = (): ReactElement => (
       <Route path="/exhibition/host" component={HostExhibition} />
 
       <Route exact path="/:username" component={Profile} />
-      <Route exact path="/:author/:title" component={Project} />
+      <Route exact path="/:authorUsername/:projectTitle" component={Project} />
     </Switch>
   </HashRouter>
 );


### PR DESCRIPTION
## Description

Previously,
```html
<Route exact path="/:author/:title" component={Project} />
```
This was unmatched with the query model. 

## Notes

We need automated frontend testing soon to prevent these. @lim-james 