### PR TITLE
🔨 REFACTOR (components): extend html attributes from container props

### DIFF
--- a/src/containers/ProfileView/index.tsx
+++ b/src/containers/ProfileView/index.tsx
@@ -1,18 +1,21 @@
-import React from "react";
+import React, { HTMLAttributes } from "react";
 
 import ProfileView from "components/ProfileView";
 import useProfileWithUsername from "hooks/useProfileWithUsername";
 import { ProfileQueryModel } from "models/User";
 
-const ProfileViewContainer: React.FC<ProfileQueryModel> = ({
+type ProfileViewProps = ProfileQueryModel & HTMLAttributes<HTMLElement>;
+
+const ProfileViewContainer: React.FC<ProfileViewProps> = ({
   username,
-}: ProfileQueryModel) => {
+  ...rest
+}: ProfileViewProps) => {
   const profile = useProfileWithUsername(username);
 
   return profile === undefined ? (
     <h1>Loading</h1>
   ) : (
-    <ProfileView {...profile} />
+    <ProfileView {...profile} {...rest} />
   );
 };
 

--- a/src/containers/ProjectList/index.tsx
+++ b/src/containers/ProjectList/index.tsx
@@ -1,15 +1,18 @@
-import React from "react";
+import React, { HTMLAttributes } from "react";
 
 import ProjectList from "components/ProjectList";
 import useUserProjects from "hooks/useUserProjects";
 import { ProjectFilterModel } from "models/Project";
 import { ProfileQueryModel } from "models/User";
 
-type ProfileListProps = ProfileQueryModel & ProjectFilterModel;
+type ProfileListProps = ProfileQueryModel &
+  ProjectFilterModel &
+  HTMLAttributes<HTMLElement>;
 
 const ProjectListContainer: React.FC<ProfileListProps> = ({
   username,
   tags,
+  ...rest
 }: ProfileListProps) => {
   const projects = useUserProjects(username);
 
@@ -18,9 +21,9 @@ const ProjectListContainer: React.FC<ProfileListProps> = ({
   }
 
   return tags === 0 ? (
-    <ProjectList projects={projects} />
+    <ProjectList projects={projects} {...rest} />
   ) : (
-    <ProjectList projects={projects.filter(p => p.tagFlags & tags)} />
+    <ProjectList projects={projects.filter(p => p.tagFlags & tags)} {...rest} />
   );
 };
 

--- a/src/containers/ProjectView/index.tsx
+++ b/src/containers/ProjectView/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { HTMLAttributes } from "react";
 
 import ProjectView from "components/ProjectView";
 import useProfileWithUsername from "hooks/useProfileWithUsername";
@@ -6,10 +6,13 @@ import useProject from "hooks/useProject";
 import useProjectRows from "hooks/useProjectRows";
 import { ProjectQueryModel } from "models/Project";
 
-const ProjectViewContainer: React.FC<ProjectQueryModel> = ({
+type ProjectViewProps = ProjectQueryModel & HTMLAttributes<HTMLElement>;
+
+const ProjectViewContainer: React.FC<ProjectViewProps> = ({
   authorUsername,
   projectTitle,
-}: ProjectQueryModel) => {
+  ...rest
+}: ProjectViewProps) => {
   const profile = useProfileWithUsername(authorUsername);
   const project = useProject(authorUsername, projectTitle);
   const rows = useProjectRows(authorUsername, projectTitle);
@@ -17,7 +20,7 @@ const ProjectViewContainer: React.FC<ProjectQueryModel> = ({
   return project === undefined ? (
     <h1>Loading</h1>
   ) : (
-    <ProjectView {...project} authorProfile={profile} rows={rows} />
+    <ProjectView {...project} authorProfile={profile} rows={rows} {...rest} />
   );
 };
 

--- a/src/containers/TagList/index.tsx
+++ b/src/containers/TagList/index.tsx
@@ -1,15 +1,18 @@
-import React from "react";
+import React, { HTMLAttributes } from "react";
 
 import TagList from "components/TagList";
 import useProfileWithUsername from "hooks/useProfileWithUsername";
 import { ProjectFilterModel } from "models/Project";
 import { ProfileQueryModel } from "models/User";
 
-type ProfileListProps = ProfileQueryModel & ProjectFilterModel;
+type ProfileListProps = ProfileQueryModel &
+  ProjectFilterModel &
+  HTMLAttributes<HTMLElement>;
 
 const TagListContainer: React.FC<ProfileListProps> = ({
   username,
   tags,
+  ...rest
 }: ProfileListProps) => {
   const profile = useProfileWithUsername(username);
 
@@ -23,7 +26,7 @@ const TagListContainer: React.FC<ProfileListProps> = ({
     username,
   }));
 
-  return <TagList tags={tagObjects} currentFilter={tags} />;
+  return <TagList tags={tagObjects} currentFilter={tags} {...rest} />;
 };
 
 export default TagListContainer;

--- a/src/layouts/Project/index.tsx
+++ b/src/layouts/Project/index.tsx
@@ -1,15 +1,13 @@
-import React, { HTMLAttributes } from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 
 import ProjectViewContainer from "containers/ProjectView";
 import { ProjectQueryModel } from "models/Project";
 
-type ProjectLayoutProps = ProjectQueryModel & HTMLAttributes<HTMLElement>;
-
-const ProjectLayout: React.FC<ProjectLayoutProps> = ({
+const ProjectLayout: React.FC<ProjectQueryModel> = ({
   authorUsername,
   projectTitle,
-}: ProjectLayoutProps) => (
+}: ProjectQueryModel) => (
   <>
     <Link to="/">Home</Link>
     <ProjectViewContainer

--- a/src/layouts/Project/index.tsx
+++ b/src/layouts/Project/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, HTMLAttributes } from "react";
+import React, { HTMLAttributes } from "react";
 import { Link } from "react-router-dom";
 
 import ProjectViewContainer from "containers/ProjectView";


### PR DESCRIPTION
## Description

Section | Extend HTMLAttributes | Rationale 
--- | --- | ---
components | yes | Primarily views, thus it is important for them to have HTMLAttributes
containers | yes | As a wrapper for views, they do not require HTMLAttributes, but should pass them down to their respective views
layouts | no | Primary purpose is to organise content with a fragment, which does not require HTMLAttributes
pages | no | Root level, should not require attributes

### Footnote
Subjected to change, this is just the current standpoint